### PR TITLE
Add the ability to set the pageload timeout setting.

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -294,6 +294,10 @@ func (wd *remoteWebDriver) SetImplicitWaitTimeout(ms uint) error {
 	return wd.voidCommand("/session/%s/timeouts/implicit_wait", timeoutParam{ms})
 }
 
+func (wd *remoteWebDriver) SetPageLoadTimeout(ms uint) error {
+	return wd.voidCommand("/session/%s/timeouts/page_load", timeoutParam{ms})
+}
+
 func (wd *remoteWebDriver) AvailableEngines() ([]string, error) {
 	return wd.stringsCommand("/session/%s/ime/available_engines")
 }

--- a/selenium.go
+++ b/selenium.go
@@ -136,6 +136,8 @@ type WebDriver interface {
 	SetAsyncScriptTimeout(ms uint) error
 	/* Set the amount of time, in milliseconds, the driver should wait when searching for elements. */
 	SetImplicitWaitTimeout(ms uint) error
+	/* Set the amount of time, in milliseconds, the driver should wait when loading a page. */
+	SetPageLoadTimeout(ms uint) error
 
 	// IME
 	/* List all available engines on the machine. */


### PR DESCRIPTION
An instance of WebDriver can now call `SetPageLoadTimeout(ms uint)
error` in order to set the “page load” timeout setting. It mimics the
SetImplicitWaitTimeout() function.
